### PR TITLE
Use Azure Key Vault to sign JARs

### DIFF
--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-prs-to-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
       TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -12,13 +12,18 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-publish-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
       build-platform: ubuntu-20.04
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
       TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
       MavenSettings: ${{ secrets.JAVA_STAGING_SETTINGS_BASE64 }}
       JavaGpgKeyPassphrase: ${{ secrets.JAVA_GPG_KEY_PASSPHRASE }}
-      CodeSigningCert: ${{ secrets.CODE_SIGNING_CERT }}
       JavaPGP: ${{ secrets.JAVA_KEY_PGP_FILE }}
-      CodeSigningCertAlias: ${{ secrets.CODE_SIGNING_CERT_ALIAS }}
-      CodeSigningCertPassword: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+      CodeSigningKeyVaultName: ${{ secrets.CODE_SIGNING_KEY_VAULT_NAME }}
+      CodeSigningKeyVaultUrl: ${{ secrets.CODE_SIGNING_KEY_VAULT_URL }}
+      CodeSigningKeyVaultClientId: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_ID }}
+      CodeSigningKeyVaultTenantId: ${{ secrets.CODE_SIGNING_KEY_VAULT_TENANT_ID }}
+      CodeSigningKeyVaultClientSecret: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_SECRET }}
+      CodeSigningKeyVaultCertificateName: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_NAME }}
+      CodeSigningKeyVaultCertificateData: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_DATA }}

--- a/ci/build-package.ps1
+++ b/ci/build-package.ps1
@@ -11,6 +11,21 @@ param(
 )
 
 
-./java/build-package.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Version $Version -ExtraArgs "-DskipNativeBuild=true" -JavaGpgKeyPassphrase $Keys['JavaGpgKeyPassphrase'] -CodeSigningCert $Keys['CodeSigningCert'] -JavaPGP $Keys['JavaPGP'] -CodeSigningCertAlias $Keys['CodeSigningCertAlias'] -CodeSigningCertPassword $Keys['CodeSigningCertPassword'] -MavenSettings $Keys['MavenSettings'] 
+./java/build-package.ps1 `
+    -RepoName $RepoName `
+    -ProjectDir $ProjectDir `
+    -Name $Name `
+    -Version $Version `
+    -ExtraArgs "-DskipNativeBuild=true" `
+    -JavaGpgKeyPassphrase $Keys['JavaGpgKeyPassphrase'] `
+    -JavaPGP $Keys['JavaPGP'] `
+    -CodeSigningKeyVaultName: $Keys['CodeSigningKeyVaultName'] `
+    -CodeSigningKeyVaultUrl $Keys['CodeSigningKeyVaultUrl'] `
+    -CodeSigningKeyVaultClientId $Keys['CodeSigningKeyVaultClientId'] `
+    -CodeSigningKeyVaultTenantId $Keys['CodeSigningKeyVaultTenantId'] `
+    -CodeSigningKeyVaultClientSecret $Keys['CodeSigningKeyVaultClientSecret'] `
+    -CodeSigningKeyVaultCertificateName $Keys['CodeSigningKeyVaultCertificateName'] `
+    -CodeSigningKeyVaultCertificateData $Keys['CodeSigningKeyVaultCertificateData'] `
+    -MavenSettings $Keys['MavenSettings'] 
 
 exit $LASTEXITCODE

--- a/pom.xml
+++ b/pom.xml
@@ -269,10 +269,20 @@
                 </executions>
                 <configuration>
                     <skip>${skippackagesign}</skip>
-                    <keystore>${keystore}</keystore>
-                    <alias>${alias}</alias>
-                    <storepass>${keystorepass}</storepass>
-                    <keypass>${keypass}</keypass>
+                    <keystore>NONE</keystore>
+                    <storetype>AZUREKEYVAULT</storetype>
+                    <alias>${keyvaultCertName}</alias>
+                    <storepass>${keyvaultAccessToken}</storepass>
+                    <providerClass>net.jsign.jca.JsignJcaProvider</providerClass>
+                    <providerArg>${keyvaultVaultName}</providerArg>
+                    <tsa>http://timestamp.globalsign.com/tsa/r6advanced1</tsa>
+                    <certchain>${keyvaultCertChain}</certchain>
+                    <arguments>
+                        <argument>-J-cp</argument>
+                        <argument>-J${keyvaultJcaJar}</argument>
+                        <argument>-J--add-modules</argument>
+                        <argument>-Jjava.sql</argument>
+                    </arguments>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Changes
- Add `org-name` to workflows.
- Use JSign as JCA Provider for signing JARs.
- Update the list of passed through secrets.

### Why
- https://github.com/postindustria-tech/51degrees-issues/issues/50

### Dependencies
- https://github.com/51Degrees/common-ci/pull/87